### PR TITLE
fix: align bin command with package name and README documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "type": "module",
     "bin": {
-      "mcp-server-puppeteer": "dist/index.js"
+      "puppeteer-mcp-server": "dist/index.js"
     },
     "files": [
       "dist"


### PR DESCRIPTION
## Problem
The executable command name doesn't match the package name and README documentation:
- Package name: `puppeteer-mcp-server`
- Actual bin command: `mcp-server-puppeteer` 
- README examples: `puppeteer-mcp-server`

This causes confusion as users following the README will encounter "command not found" errors.

## Solution
Update the bin field in package.json to match the package name and documentation.

## Changes
- Changed bin command from `mcp-server-puppeteer` to `puppeteer-mcp-server`

This ensures consistency between:
- npm package name
- executable command
- README documentation