### PR TITLE
feat: make waitUntil and timeout configurable for navigation

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -26,7 +26,16 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        url: { type: "string" },
+        url: { type: "string", description: "URL to navigate to" },
+        waitUntil: {
+          type: "string",
+          description: "When to consider navigation complete. Options: load, domcontentloaded, networkidle0, networkidle2. Default: domcontentloaded. Use networkidle0 only for static sites without WebSocket connections.",
+          enum: ["load", "domcontentloaded", "networkidle0", "networkidle2"]
+        },
+        timeout: {
+          type: "number",
+          description: "Navigation timeout in milliseconds. Default: 30000 (30 seconds)"
+        }
       },
       required: ["url"],
     },

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -66,9 +66,11 @@ export async function handleToolCall(
     case "puppeteer_navigate":
       try {
         logger.info('Navigating to URL', { url: args.url });
+        const waitUntil = args.waitUntil || 'domcontentloaded';
+        const timeout = args.timeout || 30000;
         const response = await page.goto(args.url, {
-          waitUntil: 'networkidle0',
-          timeout: 30000
+          waitUntil: waitUntil as any,
+          timeout: timeout
         });
         
         if (!response) {


### PR DESCRIPTION
## Summary

This PR makes the `waitUntil` and `timeout` parameters configurable for the `puppeteer_navigate` tool, with a more sensible default.

### Problem

The current hardcoded `waitUntil: 'networkidle0'` causes 30-second timeouts on modern web applications that maintain persistent connections:

- **Next.js** - WebSocket for Hot Module Replacement (HMR)
- **Nuxt/Vue** - Dev server WebSocket
- **SvelteKit** - Dev server WebSocket  
- **Apps with real-time features** - Chat, notifications, etc.
- **Apps with analytics** - Google Analytics and similar keep connections open

`networkidle0` waits for zero network connections, which never happens with these frameworks.

### Solution

- Add optional `waitUntil` parameter: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`
- Add optional `timeout` parameter (default: 30000ms)
- Change default from `networkidle0` to `domcontentloaded`

### Performance Impact

| waitUntil | Next.js App |
|-----------|-------------|
| `networkidle0` (old default) | **TIMEOUT** (30s) |
| `domcontentloaded` (new default) | **~100-200ms** |

### Breaking Change

Default behavior changed from `networkidle0` to `domcontentloaded`. 

**Migration:** If you specifically need the old behavior, pass `waitUntil: 'networkidle0'` explicitly.

### Usage

```javascript
// Uses new default (domcontentloaded) - fast
puppeteer_navigate({ url: "https://example.com" })

// Explicit waitUntil for static sites
puppeteer_navigate({ url: "https://example.com", waitUntil: "networkidle0" })

// Custom timeout
puppeteer_navigate({ url: "https://example.com", timeout: 60000 })
```